### PR TITLE
Fix area function definition for Circle

### DIFF
--- a/Haskell/Tipus (II).md
+++ b/Haskell/Tipus (II).md
@@ -23,7 +23,7 @@ area :: Square -> Area
 area (Square s) = s * s
 
 area :: Circle -> Area
-area (Square r) = pi * r * r
+area (Circle r) = pi * r * r
 ```
 
 Computing the `area` only make sense for certain types (what is the area of a `Bool`?). Hence, **`area` can not be defined as a parametric polymorfic function**.


### PR DESCRIPTION
Corrected the area function definition for Circle and removed the incorrect definition for Square. 😝